### PR TITLE
Add /v2 path component to module name.

### DIFF
--- a/example_object_test.go
+++ b/example_object_test.go
@@ -3,7 +3,7 @@ package goque_test
 import (
 	"fmt"
 
-	"github.com/beeker1121/goque"
+	"github.com/beeker1121/goque/v2"
 )
 
 // ExampleObject demonstrates enqueuing a struct object.

--- a/example_prefix_queue_test.go
+++ b/example_prefix_queue_test.go
@@ -3,7 +3,7 @@ package goque_test
 import (
 	"fmt"
 
-	"github.com/beeker1121/goque"
+	"github.com/beeker1121/goque/v2"
 )
 
 // ExamplePrefixQueue demonstrates the implementation of a Goque queue.

--- a/example_priority_queue_test.go
+++ b/example_priority_queue_test.go
@@ -3,7 +3,7 @@ package goque_test
 import (
 	"fmt"
 
-	"github.com/beeker1121/goque"
+	"github.com/beeker1121/goque/v2"
 )
 
 // ExamplePriorityQueue demonstrates the implementation of a Goque queue.

--- a/example_queue_test.go
+++ b/example_queue_test.go
@@ -3,7 +3,7 @@ package goque_test
 import (
 	"fmt"
 
-	"github.com/beeker1121/goque"
+	"github.com/beeker1121/goque/v2"
 )
 
 // ExampleQueue demonstrates the implementation of a Goque queue.

--- a/example_stack_test.go
+++ b/example_stack_test.go
@@ -3,7 +3,7 @@ package goque_test
 import (
 	"fmt"
 
-	"github.com/beeker1121/goque"
+	"github.com/beeker1121/goque/v2"
 )
 
 // ExampleStack demonstrates the implementation of a Goque stack.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/beeker1121/goque
+module github.com/beeker1121/goque/v2
 
 go 1.13
 


### PR DESCRIPTION
`go mod` assumes that major versions greater than v1 come with a change
to the import path. See https://blog.golang.org/v2-go-modules,
and see https://github.com/go-gorp/gorp/releases for an example of
another package that adopted Go modules and then had to fix up the
module name in order to work.

This allows other packages that use go mod to import goque.